### PR TITLE
fix: Move custom theme CSS at end of <head>

### DIFF
--- a/src/photos/targets/browser/index.ejs
+++ b/src/photos/targets/browser/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    {{.ThemeCSS}}
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
@@ -19,6 +18,7 @@
     {{.CozyClientJS}}
     {{.CozyFonts}}
     <% } %>
+    {{.ThemeCSS}}
   </head>
   <div
     role="application"

--- a/src/photos/targets/public/index.ejs
+++ b/src/photos/targets/public/index.ejs
@@ -6,7 +6,6 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <meta name="robots" content="noindex, nofollow, noimageindex">
   <title>Public Cozy Photos</title>
-  {{.ThemeCSS}}
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
     <link rel="stylesheet" href="<%- file %>">
   <% }); %>
@@ -14,6 +13,7 @@
     {{.CozyClientJS}}
     {{.CozyFonts}}
   <% } %>
+  {{.ThemeCSS}}
 </head>
 <body>
   <div


### PR DESCRIPTION
Our custom theme CSS was not taken into account because cozy-ui CSS was inserted after.



```
### 🐛 Bug Fixes

* Custom theme colors were not taken into account
```
