### PR TITLE
fix: Album creation button onClick action was broken

### DIFF
--- a/src/photos/ducks/albums/components/CreateAlbumForm.jsx
+++ b/src/photos/ducks/albums/components/CreateAlbumForm.jsx
@@ -72,6 +72,7 @@ export class CreateAlbumForm extends Component {
             value={this.state.name}
           />
           <Button
+            type="submit"
             className={styles['create-button']}
             disabled={this.state.isSubmitDisabled || this.state.isBusy}
             aria-busy={this.state.isBusy}


### PR DESCRIPTION
old button has `type submit` by default, so we need to add it manually when using new buttons