### PR TITLE
fix: Create album button blank page

### DIFF
--- a/src/photos/ducks/albums/index.jsx
+++ b/src/photos/ducks/albums/index.jsx
@@ -207,8 +207,13 @@ export const AlbumPhotosWithLoader = () => {
   }
 }
 
-const CreateAlbumPicker = ({ showAlert, t }) =>
-  withMutations(ALBUMS_MUTATIONS(showAlert, t))(PhotosPicker)
+const CreateAlbumPicker = ({ showAlert, t }) => {
+  const PhotosPickerWithMutation = withMutations(
+    ALBUMS_MUTATIONS(showAlert, t)
+  )(PhotosPicker)
+
+  return <PhotosPickerWithMutation />
+}
 
 const ConnectedPhotosPicker = ({ ...props }) => {
   const { albumId } = useParams()


### PR DESCRIPTION
In 5587dcaf4c5eee6af27de07cb476c6fc25de8cde, we added params to ALBUMS_MUTATIONS with an extra function in CreateAlbumPicker leading to the following error "Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it."



```
### ✨ Features

*

### 🐛 Bug Fixes

* "Create album" button on "Albums" page displayed a blank screen 

### 🔧 Tech

*
```
