### PR TITLE
Fix date parsed incorrectly and update Banner and Button to Twake style

### DIFF
--- a/src/components/pushClient/Banner.jsx
+++ b/src/components/pushClient/Banner.jsx
@@ -1,27 +1,28 @@
 // eslint-disable-next-line no-redeclare,no-unused-vars
 /* global localStorage */
 
-import React, { Component } from 'react'
 import localforage from 'localforage'
 import flow from 'lodash/flow'
+import React, { Component } from 'react'
 
 import { withClient } from 'cozy-client'
-import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 import Banner from 'cozy-ui/transpiled/react/Banner'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import DeviceLaptopIcon from 'cozy-ui/transpiled/react/Icons/DeviceLaptop'
+import DesktopDownloadIcon from 'cozy-ui/transpiled/react/Icons/DesktopDownload'
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
+import PhoneDownloadIcon from 'cozy-ui/transpiled/react/Icons/PhoneDownload'
+import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import {
-  isLinux,
+  getMobileAppDownloadLink,
+  getDesktopAppDownloadLink,
+  isClientAlreadyInstalled,
   isAndroid,
   isIOS,
-  isClientAlreadyInstalled,
   DESKTOP_BANNER
-} from '.'
-import Config from 'config/config.json'
-import styles from './pushClient.styl'
+} from '@/components/pushClient'
+import Config from '@/config/config.json'
 
 class BannerClient extends Component {
   state = {
@@ -57,43 +58,48 @@ class BannerClient extends Component {
 
     const { t } = this.props
 
-    const link = isIOS()
-      ? 'Nav.link-client-ios'
-      : isAndroid()
-      ? 'Nav.link-client-android'
-      : isLinux()
-      ? 'Nav.link-client'
-      : 'Nav.link-client-desktop'
-
-    const text =
-      isIOS() || isAndroid() ? 'Nav.btn-client-mobile' : 'Nav.banner-txt-client'
+    const isMobile = isIOS() || isAndroid()
+    const text = isMobile ? 'Nav.btn-client-mobile' : 'Nav.banner-txt-client'
+    const link = isMobile
+      ? getMobileAppDownloadLink({ t })
+      : getDesktopAppDownloadLink({ t })
 
     return (
-      <div className={styles['coz-banner-client']}>
+      <div className="u-pos-relative">
         <Banner
           inline
-          icon={<Icon icon={DeviceLaptopIcon} size="100%" />}
-          text={t(text)}
-          bgcolor="var(--contrastBackgroundColor)"
+          disableIconStyles
+          icon={
+            <Icon
+              className="u-mt-1 u-ml-1"
+              icon={isMobile ? PhoneDownloadIcon : DesktopDownloadIcon}
+              color="var(--primaryTextColor)"
+              size={isMobile ? 24 : 20}
+            />
+          }
+          text={t(text, {
+            name: 'Twake Drive'
+          })}
+          bgcolor="var(--defaultBackgroundColor)"
           buttonOne={
             <Button
               component="a"
-              href={t(link)}
               variant="text"
-              startIcon={<Icon icon={DownloadIcon} />}
               label={t('Nav.banner-btn-client')}
               onClick={() => this.markAsSeen('banner')}
+              startIcon={<Icon icon={DownloadIcon} />}
+              target="_blank"
+              href={link}
             />
           }
           buttonTwo={
             <Button
               variant="text"
               label={t('SelectionBar.close')}
-              onClick={() => {
-                this.markAsSeen('close')
-              }}
+              onClick={() => this.markAsSeen('close')}
             />
           }
+          noDivider
         />
       </div>
     )

--- a/src/components/pushClient/Button.jsx
+++ b/src/components/pushClient/Button.jsx
@@ -1,13 +1,22 @@
-import React, { Component } from 'react'
-import { withClient } from 'cozy-client'
 import localforage from 'localforage'
+import React, { Component } from 'react'
 
-import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
-import { default as UIButtonClient } from 'cozy-ui/transpiled/react/deprecated/PushClientButton'
+import { withClient } from 'cozy-client'
 import { isFlagshipApp } from 'cozy-device-helper'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import DriveIcon from 'cozy-ui/transpiled/react/Icons/Drive'
+import ListItem from 'cozy-ui/transpiled/react/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import { translate } from 'cozy-ui/transpiled/react/providers/I18n'
 
-import { isLinux, isClientAlreadyInstalled, DESKTOP_BANNER } from '.'
-import Config from 'config/config.json'
+import {
+  getDesktopAppDownloadLink,
+  isClientAlreadyInstalled,
+  DESKTOP_BANNER
+} from '@/components/pushClient'
+import Config from '@/config/config.json'
 
 class ButtonClient extends Component {
   state = {
@@ -34,13 +43,36 @@ class ButtonClient extends Component {
       isFlagshipApp()
     )
       return null
+
     const { t } = this.props
+
+    const link = getDesktopAppDownloadLink({ t })
+
     return (
-      <UIButtonClient
-        label={t('Nav.btn-client')}
-        href={t(isLinux() ? 'Nav.link-client' : 'Nav.link-client-desktop')}
-        className={'u-m-1 u-dn-m'}
-      />
+      <Paper
+        elevation={10}
+        className="u-mh-1-half u-mb-1-half u-c-pointer"
+        style={{ backgroundColor: 'var(--defaultBackgroundColor)' }}
+        onClick={() => window.open(link)}
+      >
+        <ListItem component="div">
+          <ListItemIcon>
+            <Icon icon={DriveIcon} size={32} />
+          </ListItemIcon>
+          <ListItemText
+            primaryTypographyProps={{
+              variant: 'overline',
+              color: 'textPrimary'
+            }}
+            primary="Twake Drive App"
+            secondaryTypographyProps={{
+              variant: 'overline',
+              color: 'primary'
+            }}
+            secondary={t('Nav.banner-btn-client')}
+          />
+        </ListItem>
+      </Paper>
     )
   }
 }

--- a/src/components/pushClient/index.js
+++ b/src/components/pushClient/index.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
 
 import CozyClient, { Q } from 'cozy-client'
+import flag from 'cozy-flags'
 
 export const DESKTOP_SOFTWARE_ID = 'github.com/cozy-labs/cozy-desktop'
 
@@ -8,9 +9,11 @@ export const isLinux = () =>
   window.navigator &&
   window.navigator.appVersion.indexOf('Win') === -1 &&
   window.navigator.appVersion.indexOf('Mac') === -1
+
 export const isAndroid = () =>
   window.navigator.userAgent &&
   window.navigator.userAgent.indexOf('Android') >= 0
+
 export const isIOS = () =>
   window.navigator.userAgent &&
   /iPad|iPhone|iPod/.test(window.navigator.userAgent)
@@ -20,9 +23,9 @@ export const NOVIEWER_DESKTOP_CTA = 'noviewer_desktop_cta'
 
 export const isClientAlreadyInstalled = async client => {
   const query = {
-    definition: Q('io.cozy.settings').getById('clients'),
+    definition: Q('io.cozy.settings').getById('io.cozy.settings.clients'),
     options: {
-      as: 'io.cozy.settings/clients',
+      as: 'io.cozy.settings/io.cozy.settings.clients',
       fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
       singleDocData: true
     }
@@ -31,4 +34,26 @@ export const isClientAlreadyInstalled = async client => {
   return Object.values(data).some(
     device => get(device, 'attributes.software_id') === DESKTOP_SOFTWARE_ID
   )
+}
+
+export const getDesktopAppDownloadLink = ({ t }) => {
+  const desktopAppDownloadLinkFromFlag = flag('cozy.desktop-app-download-link')
+
+  if (desktopAppDownloadLinkFromFlag) {
+    return desktopAppDownloadLinkFromFlag
+  } else if (isLinux()) {
+    return t('Nav.link-client')
+  } else {
+    return t('Nav.link-client-desktop')
+  }
+}
+
+export const getMobileAppDownloadLink = ({ t }) => {
+  if (isIOS()) {
+    return t('Nav.link-client-ios')
+  } else if (isAndroid()) {
+    return t('Nav.link-client-android')
+  } else {
+    return t('Nav.link-client')
+  }
 }

--- a/src/photos/ducks/timeline/dates.js
+++ b/src/photos/ducks/timeline/dates.js
@@ -3,26 +3,18 @@ import {
   differenceInCalendarMonths,
   differenceInCalendarDays,
   differenceInHours,
-  compareAsc
+  compareAsc,
+  parseISO
 } from 'date-fns'
 
 /**
- *  Format the date as specified by the formatter parameter.
- *  The extraction of year, day, etc is needed because the Date(string) constructor use the local timezone.
- *  Yet, the photos' dates are saved with the stack's locale (GMT+0 in production environment),
- *  because the timezone is mostly not specified in the EXIF metadata.
- *  So, to avoid a date offset in case the user timezone is not the stack's one, we use the Date(numbers) constructor instead.
- *  See https://github.com/date-fns/date-fns/issues/489 for more insights.
  * @param {function} f - date-fns format function
  * @param {string} date - date passed as string
- * @param {string} formatter - The wanted format. See https://date-fns.org/v1.30.1/docs/format
+ * @param {string} formatter - The wanted format. See https://date-fns.org/v2.0.0/docs/format
  * @returns {string} The formatted date
  */
 const formatDate = (f, date, formatter) => {
-  const [year, month, day] = date.substr(0, 10).split('-')
-  const [hours, minutes, seconds] =
-    date.length > 10 ? date.substr(11, 8).split(':') : [0, 0, 0]
-  return f(new Date(year, month - 1, day, hours, minutes, seconds), formatter)
+  return f(parseISO(date), formatter)
 }
 
 export const formatH = (f, date) => {
@@ -46,27 +38,25 @@ const addYear = (f, date) => {
 }
 
 export const isSameMonth = (f, newerDate, olderDate) => {
-  const newer = formatDate(f, newerDate)
-  const older = formatDate(f, olderDate)
-  return differenceInCalendarMonths(newer, older) === 0
+  return (
+    differenceInCalendarMonths(parseISO(newerDate), parseISO(olderDate)) === 0
+  )
 }
 
 export const isSameDay = (f, newerDate, olderDate) => {
-  const newer = formatDate(f, newerDate)
-  const older = formatDate(f, olderDate)
-  return differenceInCalendarDays(newer, older) === 0
+  return (
+    differenceInCalendarDays(parseISO(newerDate), parseISO(olderDate)) === 0
+  )
 }
 
 export const isSameHour = (f, newerDate, olderDate) => {
-  const newer = formatDate(f, newerDate)
-  const older = formatDate(f, olderDate)
-  return differenceInHours(newer, older) === 0
+  return differenceInHours(parseISO(newerDate), parseISO(olderDate)) === 0
 }
 
 export const isEqualOrNewer = (newerDate, olderDate) => {
-  return compareAsc(newerDate, olderDate) >= 0
+  return compareAsc(parseISO(newerDate), parseISO(olderDate)) >= 0
 }
 
 export const isEqualOrOlder = (newerDate, olderDate) => {
-  return compareAsc(newerDate, olderDate) <= 0
+  return compareAsc(parseISO(newerDate), parseISO(olderDate)) <= 0
 }


### PR DESCRIPTION
Banner and Button are component duplicated in cozy-drive. Because
- We still do not know to which extent we will keep both app separated
- I do not know if we will extend this Banner and Button components to other apps

I prefer to continue to keep component duplicated for the moment.