### PR TITLE
fix: EmptyPhotos layout not being centered 🐛

### DIFF
--- a/src/photos/styles/layout.styl
+++ b/src/photos/styles/layout.styl
@@ -5,6 +5,6 @@
     justify-content  space-between
 
 .pho-content-wrapper
-    display: flex
-    flex-direction: column
-    height: 100%
+    display flex
+    flex-direction column
+    height 100%

--- a/src/photos/styles/layout.styl
+++ b/src/photos/styles/layout.styl
@@ -3,3 +3,8 @@
 
 .pho-sidebar
     justify-content  space-between
+
+.pho-content-wrapper
+    display: flex
+    flex-direction: column
+    height: 100%


### PR DESCRIPTION
## photos view
![image](https://github.com/user-attachments/assets/f11acd37-90ad-4b34-83df-c978390c5905)

## albums view
![image](https://github.com/user-attachments/assets/08898f28-e7fe-465a-8e74-ffae0a6f5616)


## empty album view
![image](https://github.com/user-attachments/assets/cd7b44b1-471e-4811-b802-46d908fb6571)
