### PR TITLE
fix: Set correct services path

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -46,13 +46,13 @@
   "services": {
     "onPhotoUpload": {
       "type": "node",
-      "file": "services/onPhotoUpload/photos.js",
+      "file": "services/onPhotoUpload.js",
       "trigger": "@event io.cozy.files:CREATED:image:class",
       "debounce": "5m"
     },
     "onPhotoTrashed": {
       "type": "node",
-      "file": "services/onPhotoTrashed/photos.js",
+      "file": "services/onPhotoTrashed.js",
       "trigger": "@event io.cozy.files:UPDATED:image:class",
       "debounce": "5m"
     }


### PR DESCRIPTION
We forgot to update services path during rsbuild migration, so every services are not found.