### PR TITLE
fix: Do not use dataproxy for public sharings

### DIFF
--- a/src/targets/public/App.jsx
+++ b/src/targets/public/App.jsx
@@ -56,7 +56,7 @@ export class App extends Component {
 
     return (
       <Main className="u-pt-1-half">
-        <BarComponent isPublic />
+        <BarComponent isPublic={true} searchOptions={{ enabled: false }} />
         <Selection>
           {(selected, active, selection) => (
             <div>

--- a/src/targets/public/index.jsx
+++ b/src/targets/public/index.jsx
@@ -8,7 +8,6 @@ import 'photos/styles/main.styl'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import { DataProxyProvider } from 'cozy-dataproxy-lib'
 import SharingProvider from 'cozy-sharing'
 import { createStore, applyMiddleware, combineReducers } from 'redux'
 import thunkMiddleware from 'redux-thunk'
@@ -75,34 +74,32 @@ async function init() {
       <WebviewIntentProvider>
         <Provider store={store}>
           <CozyProvider client={client}>
-            <DataProxyProvider>
-              <BarProvider>
-                <BreakpointsProvider>
-                  <AlertProvider>
-                    <RealTimeQueries doctype="io.cozy.settings" />
-                    <SharingProvider
-                      doctype={DOCTYPE_ALBUMS}
-                      documentType="Albums"
-                    >
-                      <HashRouter>
-                        <SentryRoutes>
-                          <Route path="shared/:albumId" element={<App />}>
-                            <Route
-                              path=":photoId"
-                              element={<AlbumPhotosViewer isPublic={true} />}
-                            />
-                          </Route>
+            <BarProvider>
+              <BreakpointsProvider>
+                <AlertProvider>
+                  <RealTimeQueries doctype="io.cozy.settings" />
+                  <SharingProvider
+                    doctype={DOCTYPE_ALBUMS}
+                    documentType="Albums"
+                  >
+                    <HashRouter>
+                      <SentryRoutes>
+                        <Route path="shared/:albumId" element={<App />}>
                           <Route
-                            path="*"
-                            element={<Navigate to={`shared/${id}`} />}
+                            path=":photoId"
+                            element={<AlbumPhotosViewer isPublic={true} />}
                           />
-                        </SentryRoutes>
-                      </HashRouter>
-                    </SharingProvider>
-                  </AlertProvider>
-                </BreakpointsProvider>
-              </BarProvider>
-            </DataProxyProvider>
+                        </Route>
+                        <Route
+                          path="*"
+                          element={<Navigate to={`shared/${id}`} />}
+                        />
+                      </SentryRoutes>
+                    </HashRouter>
+                  </SharingProvider>
+                </AlertProvider>
+              </BreakpointsProvider>
+            </BarProvider>
           </CozyProvider>
         </Provider>
       </WebviewIntentProvider>


### PR DESCRIPTION
In the case of public sharing, we try to get an intent, which redirects to the sso as the recipient is not logged in. And this redirection is blocked by the CSP, so it silently fails.