### PR TITLE
fix: Upgrade cozy-dataproxy-lib for latest fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "classnames": "2.3.1",
     "cozy-bar": "^22.1.1",
     "cozy-client": "57.7.1",
-    "cozy-dataproxy-lib": "^4.1.0",
+    "cozy-dataproxy-lib": "^4.11.0",
     "cozy-device-helper": "^2.5.0",
     "cozy-devtools": "^1.2.1",
     "cozy-doctypes": "1.85.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5253,10 +5253,10 @@ cozy-client@57.7.1, cozy-client@^57.7.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.1.0.tgz#20d0a38e059fb5924d85f3b5a550d7d28ec9a477"
-  integrity sha512-k5lVjnpPmATEUZaYeK0B8J0+ntiNRmpmTXyDi8p6H7y41LO/yZ0XhbIqxbO4PjPnT8aKFWx3zQ7LGqIXS2Y7LA==
+cozy-dataproxy-lib@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.11.0.tgz#89cd935486517574ce1e648aab62209638afa4ab"
+  integrity sha512-4XMP8axtvpOnwlmBHug8obGCt5zU/gXABt4RLqCLi4FlsVryAGw9QYZibUPNsirGrHiMdwXrC5rrDPWAFMUUvA==
   dependencies:
     comlink "4.4.1"
     flexsearch "0.7.43"


### PR DESCRIPTION
We now have a more reliable `DataProxyProvider`